### PR TITLE
CSHARP-2316: Write reference docs for auth changes including SCRAM-SH…

### DIFF
--- a/Docs/reference/content/reference/driver/ssl.md
+++ b/Docs/reference/content/reference/driver/ssl.md
@@ -1,5 +1,5 @@
 +++
-date = "2018-04-23T07:36:42Z"
+date = "2018-07-02T12:50:42Z"
 draft = false
 title = "SSL"
 [menu.main]
@@ -42,6 +42,11 @@ var settings = new MongoClientSettings
 
 {{% note class="important" %}}It is imperative that when loading a certificate with a password, the [PrivateKey]({{< msdnref "system.security.cryptography.x509certificates.x509certificate2.privatekey" >}}) property not be null. If the property is null, it means that your certificate does not contain the private key and will not be passed to the server.{{% /note %}}
 
+### Certificate Revocation Checking
+The .NET Driver now **disables** certificate revocation checking by default, setting [`CheckCertificateRevocation`]({{< apiref "P_MongoDB_Driver_SslSettings_CheckCertificateRevocation">}}) in [`SslSettings`]({{< apiref "T_MongoDB_Driver_SslSettings" >}}) to `false` by default. Any applications relying on the older default of `true` now must explicitly set [`CheckCertificateRevocation`]({{< apiref "P_MongoDB_Driver_SslSettings_CheckCertificateRevocation">}}) to `true` in [`SslSettings`]({{< apiref "T_MongoDB_Driver_SslSettings" >}}) to re-enable certificate revocation checking.
+
+Prior to v2.7.0, the driver enabled certificate revocation checking by default, in contrast to the `mongo` shell and other MongoDB drivers. This was also in contrast to .NET's defaults for `SslStream` (see .NET Framework documentation [here](https://docs.microsoft.com/en-us/dotnet/api/system.net.security.sslstream.authenticateasclient?view=netframework-4.7.2#System_Net_Security_SslStream_AuthenticateAsClient_System_String_) and .NET Standard documentation [here](https://docs.microsoft.com/en-us/dotnet/api/system.net.security.sslstream.authenticateasclient?view=netstandard-2.0#System_Net_Security_SslStream_AuthenticateAsClient_System_String_)).
+
 ## TLS support
 ### Overview
 
@@ -54,22 +59,25 @@ var settings = new MongoClientSettings
 |         | .NET Core 1.0         | Yes    | Yes    | Yes | Yes               |
 |         | .NET Core 1.1         | Yes    | Yes    | Yes | Yes               |
 |         | .NET Core 2.0         | Yes    | Yes    | Yes | Yes               |
-|         | .NET Core 2.1-preview | Yes    | Yes    | Yes | Yes               |
+|         | .NET Core 2.1         | Yes    | Yes    | Yes | Yes               |
 | Linux   |                       |        |        |     |                   |
 |         | .NET Core 1.0         | Yes    | Yes    | No  | Yes               |
 |         | .NET Core 1.1         | Yes    | Yes    | No  | Yes               |
 |         | .NET Core 2.0         | Yes    | Yes    | No  | Yes               |
-|         | .NET Core 2.1-preview | Yes    | Yes    | Yes | Yes               |
+|         | .NET Core 2.1         | Yes    | Yes    | Yes | Yes               |
 | OSX     |                       |        |        |     |                   |
 |         | .NET Core 1.0         | Yes    | Yes    | No  | Yes               |
 |         | .NET Core 1.1         | Yes    | Yes    | No  | Yes               |
 |         | .NET Core 2.0         | Yes    | Yes    | Yes | No                |
-|         | .NET Core 2.1-preview | Yes    | Yes    | Yes | No                |
+|         | .NET Core 2.1         | Yes    | Yes    | Yes | No                |
 
 
-#### Notes:
- - SNI (Server Name Indication) required for Atlas free tier.
- - If a server's certificate includes Certificate Revocation List (CRL) Distribution Points but does not include an Online Certificate Status Protocol (OCSP) extension, .NET Core on OSX will fail to connect due to a limitation of the Apple Security Framework (see https://github.com/dotnet/corefx/issues/29064). Prior to version 2.0, .NET Core on OSX used OpenSSL, which does support CRLs without OCSP.
+#### Notes
+ - SNI (Server Name Indication) is required for Atlas free tier.
+ - .NET Core on OSX will fail to connect if **both** of the following conditions are met: (1) [certificate revocation checking]({{<relref "reference\driver\ssl.md#certificate-revocation-checking" >}}) is enabled, and (2) a server's certificate includes Certificate Revocation List (CRL) Distribution Points but does not include an Online Certificate Status Protocol (OCSP) extension.
+ 
+  - This is due to a limitation of the Apple Security Framework (see https://github.com/dotnet/corefx/issues/29064). Prior to version 2.0, .NET Core on OSX used OpenSSL, which does support CRLs without OCSP. 
+  - Connecting to Atlas on OSX with certificate revocation checking enabled will succeed since Atlas certificates include CRL Distribution Points as well as an OCSP extension.
 
 
 ### Support for TLS v1.1 and newer


### PR DESCRIPTION
…A-256

Also includes changes to the SSL page and some clarification to the text regarding upgrading from MongoDB 2.6 to 3.0.
