### PR TITLE
CSHARP-2478: Update dependency "System.Net.Security" to version 4.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Please see our [guidelines](CONTRIBUTING.md) for contributing to the driver.
 * James Hadwen              james.hadwen@sociustec.com
 * Jacob Jewell              jacobjewell@eflexsystems.com
 * Danny Kendrick            https://github.com/dkendrick
+* Ruslan Khasanbaev         https://github.com/flaksirus
 * Brian Knight              brianknight10@gmail.com  
 * Andrey Kondratyev         https://github.com/byTimo
 * Anatoly Koperin           https://github.com/ExM

--- a/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
+++ b/src/MongoDB.Driver.Core/MongoDB.Driver.Core.csproj
@@ -55,7 +55,7 @@
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.0.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="System.Net.Security" Version="4.0.0" />
+    <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="System.Security.SecureString" Version="4.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Evergreen: https://evergreen.mongodb.com/version/5c5b434ed1fe071415949be8
From: https://github.com/mongodb/mongo-csharp-driver/pull/364/
 - Updated contributors list
 - Added missing newline to README per POSIX standard (http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206).
