### PR TITLE
CSHARP-2678: Raise an actionable error message when retryWrites fails due to using an unsupported storage engine

### DIFF
--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
@@ -314,9 +314,9 @@ namespace MongoDB.Driver.Core.WireProtocol
                         var errmsg = errmsgBsonValue.ToString();
                         message = string.Format("Command {0} failed: {1}.", commandName, errmsg);
                         // https://jira.mongodb.org/browse/CSHARP-2678
-                        if (materializedDocument.TryGetValue("code", out var errorCode)
-                            && errorCode.ToInt32() == 20
-                            && errmsg.StartsWith("Transaction numbers"))
+                        if (materializedDocument.TryGetValue("code", out var errorCode) &&
+                            errorCode.ToInt32() == 20 &&
+                            errmsg.StartsWith("Transaction numbers"))
                         {
                             const string friendlyErrorMessage =
                                 "This MongoDB deployment does not support retryable writes. " +

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
@@ -312,6 +312,13 @@ namespace MongoDB.Driver.Core.WireProtocol
                     if (materializedDocument.TryGetValue("errmsg", out errmsgBsonValue) && errmsgBsonValue.IsString)
                     {
                         var errmsg = errmsgBsonValue.ToString();
+                        if (materializedDocument.TryGetValue("code", out var errorCode)
+                            && errorCode.AsInt32 == 20
+                            && errmsg.StartsWith("Transaction numbers"))
+                        {
+                            errmsg = "This MongoDB deployment does not support retryable writes. "
+                                     + "Please add retryWrites=false to your connection string.";
+                        }
                         message = string.Format("Command {0} failed: {1}.", commandName, errmsg);
                     }
                     else

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
@@ -323,7 +323,12 @@ namespace MongoDB.Driver.Core.WireProtocol
                                 "Please add retryWrites=false to your connection string.";
                             var innerException =
                                 new MongoCommandException(connectionId, message, _command, materializedDocument);
-                            throw new MongoException(friendlyErrorMessage, innerException);
+                            throw new MongoCommandException(
+                                connectionId,
+                                friendlyErrorMessage,
+                                _command,
+                                materializedDocument,
+                                innerException);
                         }
                     }
                     else

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
@@ -234,6 +234,17 @@ namespace MongoDB.Driver.Core.WireProtocol
             return new Type0CommandMessageSection<BsonDocument>(_command, elementAppendingSerializer);
         }
 
+        private bool IsRetryableWriteExceptionAndDeploymentDoesNotSupportRetryableWrites(MongoCommandException exception)
+        {
+            return
+                exception.Result.TryGetValue("code", out var errorCode) &&
+                errorCode.ToInt32() == 20 &&
+                exception.Result.TryGetValue("errmsg", out var errmsg) &&
+                errmsg.IsString &&
+                errmsg.ToString().StartsWith("Transaction numbers");
+        }
+
+
         private void MessageWasProbablySent(CommandRequestMessage message)
         {
             if (_session.Id != null)
@@ -313,30 +324,23 @@ namespace MongoDB.Driver.Core.WireProtocol
                     {
                         var errmsg = errmsgBsonValue.ToString();
                         message = string.Format("Command {0} failed: {1}.", commandName, errmsg);
-                        // https://jira.mongodb.org/browse/CSHARP-2678
-                        if (materializedDocument.TryGetValue("code", out var errorCode) &&
-                            errorCode.ToInt32() == 20 &&
-                            errmsg.StartsWith("Transaction numbers"))
-                        {
-                            const string friendlyErrorMessage =
-                                "This MongoDB deployment does not support retryable writes. " +
-                                "Please add retryWrites=false to your connection string.";
-                            var innerException =
-                                new MongoCommandException(connectionId, message, _command, materializedDocument);
-                            throw new MongoCommandException(
-                                connectionId,
-                                friendlyErrorMessage,
-                                _command,
-                                materializedDocument,
-                                innerException);
-                        }
                     }
                     else
                     {
                         message = string.Format("Command {0} failed.", commandName);
                     }
 
-                    throw new MongoCommandException(connectionId, message, _command, materializedDocument);
+                    var exception = new MongoCommandException(connectionId, message, _command, materializedDocument);
+
+                    // https://jira.mongodb.org/browse/CSHARP-2678
+                    if (IsRetryableWriteExceptionAndDeploymentDoesNotSupportRetryableWrites(exception))
+                    {
+                        throw WrapNotSupportedRetryableWriteException(exception);
+                    }
+                    else
+                    {
+                        throw exception;
+                    }
                 }
 
                 if (rawDocument.Contains("writeConcernError"))
@@ -370,6 +374,19 @@ namespace MongoDB.Driver.Core.WireProtocol
             }
 
             return false;
+        }
+
+        private MongoException WrapNotSupportedRetryableWriteException(MongoCommandException exception)
+        {
+            const string friendlyErrorMessage =
+                "This MongoDB deployment does not support retryable writes. " +
+                "Please add retryWrites=false to your connection string.";
+            return new MongoCommandException(
+                exception.ConnectionId,
+                friendlyErrorMessage,
+                exception.Command,
+                exception.Result,
+                innerException: exception);
         }
     }
 }

--- a/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
+++ b/src/MongoDB.Driver.Core/Core/WireProtocol/CommandUsingCommandMessageWireProtocol.cs
@@ -240,8 +240,7 @@ namespace MongoDB.Driver.Core.WireProtocol
                 exception.Result.TryGetValue("code", out var errorCode) &&
                 errorCode.ToInt32() == 20 &&
                 exception.Result.TryGetValue("errmsg", out var errmsg) &&
-                errmsg.IsString &&
-                errmsg.ToString().StartsWith("Transaction numbers");
+                errmsg.AsString.StartsWith("Transaction numbers");
         }
 
 

--- a/src/MongoDB.Driver.Core/MongoCommandException.cs
+++ b/src/MongoDB.Driver.Core/MongoCommandException.cs
@@ -75,7 +75,21 @@ namespace MongoDB.Driver
         /// <param name="command">The command.</param>
         /// <param name="result">The command result.</param>
         public MongoCommandException(ConnectionId connectionId, string message, BsonDocument command, BsonDocument result)
-            : base(connectionId, message)
+            : this(connectionId, message, command, result, innerException: null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MongoCommandException"/> class.
+        /// </summary>
+        /// <param name="connectionId">The connection identifier.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="command">The command.</param>
+        /// // <param name="result">The command result.</param>
+        /// <param name="innerException">The inner exception.</param>
+        ///
+        public MongoCommandException(ConnectionId connectionId, string message, BsonDocument command, BsonDocument result, Exception innerException)
+            : base(connectionId, message, innerException)
         {
             _command = command; // can be null
             _result = result; // can be null

--- a/tests/MongoDB.Driver.Tests/RetryableWritesTests.cs
+++ b/tests/MongoDB.Driver.Tests/RetryableWritesTests.cs
@@ -24,11 +24,19 @@ using MongoDB.Driver.Core.Events;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.Driver.TestHelpers;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace MongoDB.Driver.Tests
 {
     public class RetryableWritesTests
     {
+        private static ITestOutputHelper _output;
+
+        public RetryableWritesTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [SkippableFact]
         public void Insert_with_RetryWrites_true_should_work_whether_retryable_writes_are_supported_or_not()
         {
@@ -49,17 +57,19 @@ namespace MongoDB.Driver.Tests
             RequireSupportForRetryableWrites();
             RequireServer.Check().StorageEngine("mmapv1");
 
-            using (var client = GetClient(builder =>  { }))
+            using (var client = GetClient())
             using (var session = client.StartSession())
             {
                 var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
                 var collection = database.GetCollection<BsonDocument>(DriverTestConfiguration.CollectionNamespace.CollectionName);
                 var document = new BsonDocument("x", 1);
-                var exception = Record.Exception(()=>collection.InsertOne(document));
+                var exception = Record.Exception(() => collection.InsertOne(document));
 
                 exception.Message.Should().Contain(
-                    "This MongoDB deployment does not support retryable writes. "
-                    + "Please add retryWrites=false to your connection string.");
+                    "This MongoDB deployment does not support retryable writes. " +
+                    "Please add retryWrites=false to your connection string.");
+
+                _output.WriteLine("The cake isn't a lie.");
             }
         }
 

--- a/tests/MongoDB.Driver.Tests/RetryableWritesTests.cs
+++ b/tests/MongoDB.Driver.Tests/RetryableWritesTests.cs
@@ -44,6 +44,26 @@ namespace MongoDB.Driver.Tests
         }
 
         [SkippableFact]
+        public void Retryable_write_operation_should_throw_custom_exception_on_servers_using_mmapv1()
+        {
+            RequireSupportForRetryableWrites();
+            RequireServer.Check().StorageEngine("mmapv1");
+
+            using (var client = GetClient(builder =>  { }))
+            using (var session = client.StartSession())
+            {
+                var database = client.GetDatabase(DriverTestConfiguration.DatabaseNamespace.DatabaseName);
+                var collection = database.GetCollection<BsonDocument>(DriverTestConfiguration.CollectionNamespace.CollectionName);
+                var document = new BsonDocument("x", 1);
+                var exception = Record.Exception(()=>collection.InsertOne(document));
+
+                exception.Message.Should().Contain(
+                    "This MongoDB deployment does not support retryable writes. "
+                    + "Please add retryWrites=false to your connection string.");
+            }
+        }
+
+        [SkippableFact]
         public void TxnNumber_should_be_included_with_FindOneAndDelete()
         {
             RequireSupportForRetryableWrites();

--- a/tests/MongoDB.Driver.Tests/RetryableWritesTests.cs
+++ b/tests/MongoDB.Driver.Tests/RetryableWritesTests.cs
@@ -24,7 +24,6 @@ using MongoDB.Driver.Core.Events;
 using MongoDB.Driver.Core.TestHelpers.XunitExtensions;
 using MongoDB.Driver.TestHelpers;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace MongoDB.Driver.Tests
 {

--- a/tests/MongoDB.Driver.Tests/RetryableWritesTests.cs
+++ b/tests/MongoDB.Driver.Tests/RetryableWritesTests.cs
@@ -30,8 +30,6 @@ namespace MongoDB.Driver.Tests
 {
     public class RetryableWritesTests
     {
-        private static ITestOutputHelper _output;
-
         [SkippableFact]
         public void Insert_with_RetryWrites_true_should_work_whether_retryable_writes_are_supported_or_not()
         {

--- a/tests/MongoDB.Driver.Tests/RetryableWritesTests.cs
+++ b/tests/MongoDB.Driver.Tests/RetryableWritesTests.cs
@@ -32,11 +32,6 @@ namespace MongoDB.Driver.Tests
     {
         private static ITestOutputHelper _output;
 
-        public RetryableWritesTests(ITestOutputHelper output)
-        {
-            _output = output;
-        }
-
         [SkippableFact]
         public void Insert_with_RetryWrites_true_should_work_whether_retryable_writes_are_supported_or_not()
         {
@@ -68,8 +63,6 @@ namespace MongoDB.Driver.Tests
                 exception.Message.Should().Contain(
                     "This MongoDB deployment does not support retryable writes. " +
                     "Please add retryWrites=false to your connection string.");
-
-                _output.WriteLine("The cake isn't a lie.");
             }
         }
 

--- a/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/RetryableWriteTestRunner.cs
+++ b/tests/MongoDB.Driver.Tests/Specifications/retryable-writes/RetryableWriteTestRunner.cs
@@ -55,6 +55,11 @@ namespace MongoDB.Driver.Tests.Specifications.retryable_writes
         {
             RequireServer.Check().ClusterType(ClusterType.ReplicaSet);
 
+            if (CoreTestConfiguration.GetStorageEngine() == "mmapv1")
+            {
+                throw new SkipException("Test skipped because mmapv1 does not support retryable writes.");
+            }
+
             BsonValue minServerVersion;
             if (definition.TryGetValue("minServerVersion", out minServerVersion))
             {


### PR DESCRIPTION
https://jira.mongodb.org/browse/CSHARP-2678
https://evergreen.mongodb.com/version/5d51d276c9ec4411f828c808

Newly added test passes locally on 4.0 replicaset w/ mmapv1.