### PR TITLE
CSHARP-2691: Update current version in reference docs to 2.9

### DIFF
--- a/Docs/landing/data/releases.toml
+++ b/Docs/landing/data/releases.toml
@@ -1,7 +1,12 @@
-current = "2.8.0"
+current = "2.9.0"
 [[versions]]
-  version = "2.8.0"
+  version = "2.9.0"
   status = "current"
+  docs = "./2.9/"
+  api = "./2.9/apidocs"
+
+[[versions]]
+  version = "2.8.1"
   docs = "./2.8/"
   api = "./2.8/apidocs"
 

--- a/Docs/landing/static/versions.json
+++ b/Docs/landing/static/versions.json
@@ -1,4 +1,5 @@
 [
+    {"version": "2.9"},
     {"version": "2.8"},
     {"version": "2.7"},
     {"version": "2.6"},

--- a/Docs/reference/config.toml
+++ b/Docs/reference/config.toml
@@ -1,4 +1,4 @@
-baseurl = "/mongo-csharp-driver/2.8"
+baseurl = "/mongo-csharp-driver/2.9"
 languageCode = "en-us"
 title = "MongoDB .NET Driver"
 theme = "mongodb"

--- a/Docs/reference/content/index.md
+++ b/Docs/reference/content/index.md
@@ -9,11 +9,9 @@ type = "index"
 
 The [Getting Started]({{< relref "getting_started\index.md" >}}) guide contains information about system requirements, installation, and a simple tutorial to get up and running quickly.
 
-## What's new in 2.8.0
+## What's new in 2.9.0
 
 The [What's New]({{< relref "what_is_new.md" >}}) section contains the major new features of the driver.
-
-The 2.8.0 driver includes bug fixes and depends on newer versions of several external dependencies.
 
 ## Upgrading
 

--- a/Docs/reference/content/what_is_new.md
+++ b/Docs/reference/content/what_is_new.md
@@ -13,6 +13,18 @@ title = "What's New"
 Some of the changes in 2.9.0 include:
 
 * Retryable writes are enabled by default
+* Retryable reads support (enabled by default)
+* Distributed transactions on sharded clusters
+* Convenient API for transactions via `IClientSession.WithTransaction()`
+* Support for message compression
+* SRV polling for `mongodb+srv` connection scheme
+* Update specification using an aggregation framework pipeline
+* SCRAM-SHA authentication caching
+* Connections to the replica set primary are no longer closed after a step-down, allowing in progress read operations to complete
+* New aggregate helper methods support running database-level aggregations
+* `$merge` support
+* Change stream helpers now support the `startAfter` option
+* Index creation helpers now support wildcard indexes
 
 ## What's New in 2.8.0
 

--- a/Docs/reference/data/mongodb.toml
+++ b/Docs/reference/data/mongodb.toml
@@ -1,5 +1,5 @@
 githubRepo = "mongo-csharp-driver"
 githubBranch = "master"
-currentVersion = "2.8"
+currentVersion = "2.9"
 highlightTheme = "idea.css"
 apiUrl = "apidocs/html"


### PR DESCRIPTION
Modeled after: https://github.com/rstam/mongo-csharp-driver/pull/112