### PR TITLE
CSHARP-2779: Update landing page to fix inconsistencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
         <option value="0"disabled="disabled">2.10.0-beta1</option>
         
         
-        <option value="1"disabled="disabled">2.9.2</option>
+        <option value="1"disabled="disabled" selected="selected">2.9.2</option>
         
         
         <option value="2"disabled="disabled">2.8.1</option>
@@ -203,7 +203,7 @@
           
           
           
-<div id="nuget-0-0" class="download ">
+<div id="nuget-0-0" class="download hidden">
 <pre><code>&lt;packages&gt;
     &lt;package id="MongoDB.Driver" version="2.10.0-beta1" /&gt;
     &lt;package id="MongoDB.Driver.Core" version="2.10.0-beta1" /&gt;
@@ -226,7 +226,7 @@ nuget MongoDB.Driver ~> 2.10.0-beta1
           
           
           
-<div id="nuget-1-0" class="download  hidden">
+<div id="nuget-1-0" class="download">
 <pre><code>&lt;packages&gt;
     &lt;package id="MongoDB.Driver" version="2.9.2" /&gt;
     &lt;package id="MongoDB.Driver.Core" version="2.9.2" /&gt;


### PR DESCRIPTION
This PR is for the manual edits needed to make our landing page look consistent. Without these changes, the "download" button points 2.9.2, but the dropdown and "code sample" box show 2.10.0-beta1.  This PR is against the branch that contains gh-pages result of CSHARP-2778/https://github.com/vincentkam/mongo-csharp-driver/pull/67

The changes are currently live here: https://vincentkam.github.io/mongo-csharp-driver/