### PR TITLE
CSHARP-2795: Investigate testing code path that may only execute from within an IDE

### DIFF
--- a/tests/MongoDB.Bson.TestHelpers/JsonDrivenTests/JsonDrivenTestCase.cs
+++ b/tests/MongoDB.Bson.TestHelpers/JsonDrivenTests/JsonDrivenTestCase.cs
@@ -53,6 +53,7 @@ namespace MongoDB.Bson.TestHelpers.JsonDrivenTests
             _name = info.GetValue<string>(nameof(_name));
             _shared = DeserializeBsonDocument(info.GetValue<string>(nameof(_shared)));
             _test = DeserializeBsonDocument(info.GetValue<string>(nameof(_test)));
+            File.AppendAllText(@"C:\temp\hello.txt", "Hello there!");
         }
 
         public void Serialize(IXunitSerializationInfo info)


### PR DESCRIPTION
Not sure if a PR is the best way to discuss this: let me know if you guys would rather discuss this on JIRA!

https://jira.mongodb.org/browse/CSHARP-2795

 - Reproduction steps:
   - run the retryable reads tests from the console from the `MongoDB.Driver.Tests` directory:
     - `dotnet test --filter FullyQualifiedName~retryable_reads -- RunConfiguration.TargetPlatform=x64`
       - this runs both the netfw and netcore tests
     - run `cat C:\temp\hello.txt` and note that the file doesn't exist
   - Now run the same retryable reads tests from the IDE, specifically the .NET Framework 4.5.2 version
     - run `cat C:\temp\hello.txt` and note that the file doesn't exist
   - Now run the same retryable reads tests from the IDE, specifically the .NET Core 2.1 tests
     - run `cat C:\temp\hello.txt` and note that the file exists and is full of text


