### PR TITLE
CSHARP-2848+2849: Update landing page + Sync refdocs

### DIFF
--- a/2.9/index.xml
+++ b/2.9/index.xml
@@ -1009,106 +1009,6 @@ Task AbortTransactionAsync(CancellationToken cancellationToken = default(Cancell
     </item>
     
     <item>
-      <title>Deleting and Renaming Files</title>
-      <link>/mongo-csharp-driver/2.9/reference/gridfs/deletingandrenamingfiles/</link>
-      <pubDate>Mon, 14 Sep 2015 00:00:00 +0000</pubDate>
-      
-      <guid>/mongo-csharp-driver/2.9/reference/gridfs/deletingandrenamingfiles/</guid>
-      <description>
-
-&lt;h2 id=&#34;deleting-and-renaming-files&#34;&gt;Deleting and Renaming Files&lt;/h2&gt;
-
-&lt;p&gt;These methods allow you to delete or rename GridFS files.&lt;/p&gt;
-
-&lt;h3 id=&#34;deleting-a-single-file&#34;&gt;Deleting a single file&lt;/h3&gt;
-
-&lt;p&gt;Use the &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_Delete.htm
-&#34;&gt;&lt;code&gt;Delete&lt;/code&gt;&lt;/a&gt; or &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_DeleteAsync.htm
-&#34;&gt;&lt;code&gt;DeleteAsync&lt;/code&gt;&lt;/a&gt; methods to delete a single file identified by its Id.&lt;/p&gt;
-
-&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;IGridFSBucket bucket;
-ObjectId id;
-&lt;/code&gt;&lt;/pre&gt;
-
-&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;bucket.Delete(id);
-&lt;/code&gt;&lt;/pre&gt;
-
-&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;await bucket.DeleteAsync(id);
-&lt;/code&gt;&lt;/pre&gt;
-
-&lt;h3 id=&#34;dropping-an-entire-gridfs-bucket&#34;&gt;Dropping an entire GridFS bucket&lt;/h3&gt;
-
-&lt;p&gt;Use the &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_Drop.htm
-&#34;&gt;&lt;code&gt;Drop&lt;/code&gt;&lt;/a&gt; or &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_DropAsync.htm
-&#34;&gt;&lt;code&gt;DropAsync&lt;/code&gt;&lt;/a&gt; methods to drop an entire GridFS bucket at once.&lt;/p&gt;
-
-&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;IGridFSBucket bucket;
-&lt;/code&gt;&lt;/pre&gt;
-
-&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;bucket.Drop();
-&lt;/code&gt;&lt;/pre&gt;
-
-&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;await bucket.DropAsync();
-&lt;/code&gt;&lt;/pre&gt;
-
-&lt;p&gt;&lt;div class=&#34;admonition note&#34;&gt;
-&lt;h5 class=&#34;admonition-title&#34;&gt;Note&lt;/h5&gt;
-The &amp;ldquo;fs.files&amp;rdquo; collection will be dropped first, followed by the &amp;ldquo;fs.chunks&amp;rdquo; collection. This is the fastest way to delete all files stored in a GridFS bucket at once.
-&lt;/div&gt;
-&lt;/p&gt;
-
-&lt;h3 id=&#34;renaming-a-single-file&#34;&gt;Renaming a single file&lt;/h3&gt;
-
-&lt;p&gt;Use the &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_Rename.htm
-&#34;&gt;&lt;code&gt;Rename&lt;/code&gt;&lt;/a&gt; or &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_RenameAsync.htm
-&#34;&gt;&lt;code&gt;RenameAsync&lt;/code&gt;&lt;/a&gt; methods to rename a single file identified by its Id.&lt;/p&gt;
-
-&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;IGridFSBucket bucket;
-ObjectId id;
-string newFilename;
-&lt;/code&gt;&lt;/pre&gt;
-
-&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;bucket.Rename(id, newFilename);
-&lt;/code&gt;&lt;/pre&gt;
-
-&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;await bucket.RenameAsync(id, newFilename);
-&lt;/code&gt;&lt;/pre&gt;
-
-&lt;h3 id=&#34;renaming-all-revisions-of-a-file&#34;&gt;Renaming all revisions of a file&lt;/h3&gt;
-
-&lt;p&gt;To rename all revisions of a file you first use the &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/_MongoDB_Driver_GridFS_IGridFSBucket_Find.htm
-&#34;&gt;&lt;code&gt;Find&lt;/code&gt;&lt;/a&gt; or &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/_MongoDB_Driver_GridFS_IGridFSBucket_FindAsync.htm
-&#34;&gt;&lt;code&gt;FindAsync&lt;/code&gt;&lt;/a&gt; method to find all the revisions, and then loop over the revisions and use the &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_Rename.htm
-&#34;&gt;&lt;code&gt;Rename&lt;/code&gt;&lt;/a&gt; or &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_RenameAsync.htm
-&#34;&gt;&lt;code&gt;RenameAsync&lt;/code&gt;&lt;/a&gt; method to rename each revision one at a time.&lt;/p&gt;
-
-&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;IGridFSBucket bucket;
-string oldFilename;
-string newFilename;
-var filter = Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.EQ(x =&amp;gt; x.Filename, oldFilename);
-&lt;/code&gt;&lt;/pre&gt;
-
-&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;var filesCursor = bucket.Find(filter);
-var files = filesCursor.ToList();
-
-foreach (var file in files)
-{
-    bucket.Rename(file.Id, newFilename);
-}
-&lt;/code&gt;&lt;/pre&gt;
-
-&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;var filesCursor = await bucket.FindAsync(filter);
-var files = await filesCursor.ToListAsync();
-
-foreach (var file in files)
-{
-    await bucket.RenameAsync(file.Id, newFilename);
-}
-&lt;/code&gt;&lt;/pre&gt;
-</description>
-    </item>
-    
-    <item>
       <title>Downloading Files</title>
       <link>/mongo-csharp-driver/2.9/reference/gridfs/downloadingfiles/</link>
       <pubDate>Mon, 14 Sep 2015 00:00:00 +0000</pubDate>
@@ -1359,9 +1259,9 @@ using (var stream = await bucket.OpenDownloadStreamByNameAsync(filename, options
 
 &lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;IGridFSBucket bucket;
 var filter = Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.And( 
-    Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.EQ(x =&amp;gt; x.Filename, &amp;quot;securityvideo&amp;quot;),
-    Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.GTE(x =&amp;gt; x.UploadDateTime, new DateTime(2015, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
-    Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.LT(x =&amp;gt; x.UploadDateTime, new DateTime(2015, 2, 1, 0, 0, 0, DateTimeKind.Utc)));
+    Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.Eq(x =&amp;gt; x.Filename, &amp;quot;securityvideo&amp;quot;),
+    Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.Gte(x =&amp;gt; x.UploadDateTime, new DateTime(2015, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+    Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.Lt(x =&amp;gt; x.UploadDateTime, new DateTime(2015, 2, 1, 0, 0, 0, DateTimeKind.Utc)));
 var sort = Builders&amp;lt;GridFSFileInfo&amp;gt;.Sort.Descending(x =&amp;gt; x.UploadDateTime);
 var options = new GridFSFindOptions
 {
@@ -1450,7 +1350,7 @@ var bucket = new GridFSBucket(database, new GridFSBucketOptions
 &#34;&gt;&lt;code&gt;BucketName&lt;/code&gt;&lt;/a&gt; value is the root part of the files and chunks collection names, so in this example the two collections would be named &amp;ldquo;videos.files&amp;rdquo; and &amp;ldquo;videos.chunks&amp;rdquo; instead of &amp;ldquo;fs.files&amp;rdquo; and &amp;ldquo;fs.chunks&amp;rdquo;.&lt;/p&gt;
 
 &lt;p&gt;The &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/P_MongoDB_Driver_GridFS_GridFSBucketOptions_ChunkSizeBytes.htm
-&#34;&gt;&lt;code&gt;ChunkSizeBytes&lt;/code&gt;&lt;/a&gt; value defines the size of each chunk, and in this example we are overriding the default value of 261120 (255MB).&lt;/p&gt;
+&#34;&gt;&lt;code&gt;ChunkSizeBytes&lt;/code&gt;&lt;/a&gt; value defines the size of each chunk, and in this example we are overriding the default value of 261120 (255kB).&lt;/p&gt;
 
 &lt;p&gt;The &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/P_MongoDB_Driver_GridFS_GridFSBucketOptions_WriteConcern.htm
 &#34;&gt;&lt;code&gt;WriteConcern&lt;/code&gt;&lt;/a&gt; is used when uploading files to GridFS, and the &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/P_MongoDB_Driver_GridFS_GridFSBucketOptions_ReadPreference.htm
@@ -1629,6 +1529,106 @@ var options = new GridFSUploadOptions
     var id = stream.Id; // the unique Id of the file being uploaded
     // write the contents of the file to stream
     await stream.CloseAsync();
+}
+&lt;/code&gt;&lt;/pre&gt;
+</description>
+    </item>
+    
+    <item>
+      <title>Deleting and Renaming Files</title>
+      <link>/mongo-csharp-driver/2.9/reference/gridfs/deletingandrenamingfiles/</link>
+      <pubDate>Mon, 14 Sep 2015 00:00:00 +0000</pubDate>
+      
+      <guid>/mongo-csharp-driver/2.9/reference/gridfs/deletingandrenamingfiles/</guid>
+      <description>
+
+&lt;h2 id=&#34;deleting-and-renaming-files&#34;&gt;Deleting and Renaming Files&lt;/h2&gt;
+
+&lt;p&gt;These methods allow you to delete or rename GridFS files.&lt;/p&gt;
+
+&lt;h3 id=&#34;deleting-a-single-file&#34;&gt;Deleting a single file&lt;/h3&gt;
+
+&lt;p&gt;Use the &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_Delete.htm
+&#34;&gt;&lt;code&gt;Delete&lt;/code&gt;&lt;/a&gt; or &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_DeleteAsync.htm
+&#34;&gt;&lt;code&gt;DeleteAsync&lt;/code&gt;&lt;/a&gt; methods to delete a single file identified by its Id.&lt;/p&gt;
+
+&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;IGridFSBucket bucket;
+ObjectId id;
+&lt;/code&gt;&lt;/pre&gt;
+
+&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;bucket.Delete(id);
+&lt;/code&gt;&lt;/pre&gt;
+
+&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;await bucket.DeleteAsync(id);
+&lt;/code&gt;&lt;/pre&gt;
+
+&lt;h3 id=&#34;dropping-an-entire-gridfs-bucket&#34;&gt;Dropping an entire GridFS bucket&lt;/h3&gt;
+
+&lt;p&gt;Use the &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_Drop.htm
+&#34;&gt;&lt;code&gt;Drop&lt;/code&gt;&lt;/a&gt; or &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_DropAsync.htm
+&#34;&gt;&lt;code&gt;DropAsync&lt;/code&gt;&lt;/a&gt; methods to drop an entire GridFS bucket at once.&lt;/p&gt;
+
+&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;IGridFSBucket bucket;
+&lt;/code&gt;&lt;/pre&gt;
+
+&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;bucket.Drop();
+&lt;/code&gt;&lt;/pre&gt;
+
+&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;await bucket.DropAsync();
+&lt;/code&gt;&lt;/pre&gt;
+
+&lt;p&gt;&lt;div class=&#34;admonition note&#34;&gt;
+&lt;h5 class=&#34;admonition-title&#34;&gt;Note&lt;/h5&gt;
+The &amp;ldquo;fs.files&amp;rdquo; collection will be dropped first, followed by the &amp;ldquo;fs.chunks&amp;rdquo; collection. This is the fastest way to delete all files stored in a GridFS bucket at once.
+&lt;/div&gt;
+&lt;/p&gt;
+
+&lt;h3 id=&#34;renaming-a-single-file&#34;&gt;Renaming a single file&lt;/h3&gt;
+
+&lt;p&gt;Use the &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_Rename.htm
+&#34;&gt;&lt;code&gt;Rename&lt;/code&gt;&lt;/a&gt; or &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_RenameAsync.htm
+&#34;&gt;&lt;code&gt;RenameAsync&lt;/code&gt;&lt;/a&gt; methods to rename a single file identified by its Id.&lt;/p&gt;
+
+&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;IGridFSBucket bucket;
+ObjectId id;
+string newFilename;
+&lt;/code&gt;&lt;/pre&gt;
+
+&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;bucket.Rename(id, newFilename);
+&lt;/code&gt;&lt;/pre&gt;
+
+&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;await bucket.RenameAsync(id, newFilename);
+&lt;/code&gt;&lt;/pre&gt;
+
+&lt;h3 id=&#34;renaming-all-revisions-of-a-file&#34;&gt;Renaming all revisions of a file&lt;/h3&gt;
+
+&lt;p&gt;To rename all revisions of a file you first use the &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/_MongoDB_Driver_GridFS_IGridFSBucket_Find.htm
+&#34;&gt;&lt;code&gt;Find&lt;/code&gt;&lt;/a&gt; or &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/_MongoDB_Driver_GridFS_IGridFSBucket_FindAsync.htm
+&#34;&gt;&lt;code&gt;FindAsync&lt;/code&gt;&lt;/a&gt; method to find all the revisions, and then loop over the revisions and use the &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_Rename.htm
+&#34;&gt;&lt;code&gt;Rename&lt;/code&gt;&lt;/a&gt; or &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/M_MongoDB_Driver_GridFS_IGridFSBucket_RenameAsync.htm
+&#34;&gt;&lt;code&gt;RenameAsync&lt;/code&gt;&lt;/a&gt; method to rename each revision one at a time.&lt;/p&gt;
+
+&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;IGridFSBucket bucket;
+string oldFilename;
+string newFilename;
+var filter = Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.EQ(x =&amp;gt; x.Filename, oldFilename);
+&lt;/code&gt;&lt;/pre&gt;
+
+&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;var filesCursor = bucket.Find(filter);
+var files = filesCursor.ToList();
+
+foreach (var file in files)
+{
+    bucket.Rename(file.Id, newFilename);
+}
+&lt;/code&gt;&lt;/pre&gt;
+
+&lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;var filesCursor = await bucket.FindAsync(filter);
+var files = await filesCursor.ToListAsync();
+
+foreach (var file in files)
+{
+    await bucket.RenameAsync(file.Id, newFilename);
 }
 &lt;/code&gt;&lt;/pre&gt;
 </description>
@@ -1845,7 +1845,7 @@ These are heavy events to generate. Do not subscribe to these unless they provid
 &lt;h2 id=&#34;linq&#34;&gt;LINQ&lt;/h2&gt;
 
 &lt;p&gt;The driver contains an implementation of &lt;a href=&#34;https://msdn.microsoft.com/en-us/library/bb397926.aspx&#34;&gt;LINQ&lt;/a&gt; that targets the &lt;a href=&#34;http://docs.mongodb.org/manual/aggregation
-&#34;&gt;aggregation framework&lt;/a&gt;. The aggregation framework holds a rich query language that maps very easily from a LINQ expression tree making it straightforward to understand the translation from a LINQ statement into an aggregation framework pipeline. To see a more complicated uses of LINQ from the driver, see the &lt;a href=&#34;﻿https://github.com/mongodb/mongo-csharp-driver/blob/master/tests/MongoDB.Driver.Tests/Samples/AggregationSample.cs
+&#34;&gt;aggregation framework&lt;/a&gt;. The aggregation framework holds a rich query language that maps very easily from a LINQ expression tree making it straightforward to understand the translation from a LINQ statement into an aggregation framework pipeline. To see a more complicated uses of LINQ from the driver, see the &lt;a href=&#34;https://github.com/mongodb/mongo-csharp-driver/blob/master/tests/MongoDB.Driver.Tests/Samples/AggregationSample.cs
 &#34;&gt;AggregationSample&lt;/a&gt; source code.&lt;/p&gt;
 
 &lt;p&gt;For the rest of this page, we&amp;rsquo;ll use the following class:&lt;/p&gt;
@@ -2161,7 +2161,7 @@ var query = collection.AsQueryable()
 
 &lt;h3 id=&#34;supported-methods&#34;&gt;Supported Methods&lt;/h3&gt;
 
-&lt;p&gt;The method examples are shown in isolation, but they can be used and combined with all the other methods as well. You can view the tests for each of these methods in the &lt;a href=&#34;﻿https://github.com/mongodb/mongo-csharp-driver/blob/master/tests/MongoDB.Driver.Tests/Linq/MongoQueryableTests.cs
+&lt;p&gt;The method examples are shown in isolation, but they can be used and combined with all the other methods as well. You can view the tests for each of these methods in the &lt;a href=&#34;https://github.com/mongodb/mongo-csharp-driver/blob/master/tests/MongoDB.Driver.Tests/Linq/MongoQueryableTests.cs
 &#34;&gt;MongoQueryableTests&lt;/a&gt;.&lt;/p&gt;
 
 &lt;h4 id=&#34;any&#34;&gt;Any&lt;/h4&gt;

--- a/2.9/reference/gridfs/findingfiles/index.html
+++ b/2.9/reference/gridfs/findingfiles/index.html
@@ -2721,9 +2721,9 @@
 
 <pre><code class="language-csharp">IGridFSBucket bucket;
 var filter = Builders&lt;GridFSFileInfo&gt;.Filter.And( 
-    Builders&lt;GridFSFileInfo&gt;.Filter.EQ(x =&gt; x.Filename, &quot;securityvideo&quot;),
-    Builders&lt;GridFSFileInfo&gt;.Filter.GTE(x =&gt; x.UploadDateTime, new DateTime(2015, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
-    Builders&lt;GridFSFileInfo&gt;.Filter.LT(x =&gt; x.UploadDateTime, new DateTime(2015, 2, 1, 0, 0, 0, DateTimeKind.Utc)));
+    Builders&lt;GridFSFileInfo&gt;.Filter.Eq(x =&gt; x.Filename, &quot;securityvideo&quot;),
+    Builders&lt;GridFSFileInfo&gt;.Filter.Gte(x =&gt; x.UploadDateTime, new DateTime(2015, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+    Builders&lt;GridFSFileInfo&gt;.Filter.Lt(x =&gt; x.UploadDateTime, new DateTime(2015, 2, 1, 0, 0, 0, DateTimeKind.Utc)));
 var sort = Builders&lt;GridFSFileInfo&gt;.Sort.Descending(x =&gt; x.UploadDateTime);
 var options = new GridFSFindOptions
 {

--- a/2.9/reference/gridfs/gettingstarted/index.html
+++ b/2.9/reference/gridfs/gettingstarted/index.html
@@ -2678,7 +2678,7 @@ var bucket = new GridFSBucket(database, new GridFSBucketOptions
 "><code>BucketName</code></a> value is the root part of the files and chunks collection names, so in this example the two collections would be named &ldquo;videos.files&rdquo; and &ldquo;videos.chunks&rdquo; instead of &ldquo;fs.files&rdquo; and &ldquo;fs.chunks&rdquo;.</p>
 
 <p>The <a href="/mongo-csharp-driver/2.9/apidocs/html/P_MongoDB_Driver_GridFS_GridFSBucketOptions_ChunkSizeBytes.htm
-"><code>ChunkSizeBytes</code></a> value defines the size of each chunk, and in this example we are overriding the default value of 261120 (255MB).</p>
+"><code>ChunkSizeBytes</code></a> value defines the size of each chunk, and in this example we are overriding the default value of 261120 (255kB).</p>
 
 <p>The <a href="/mongo-csharp-driver/2.9/apidocs/html/P_MongoDB_Driver_GridFS_GridFSBucketOptions_WriteConcern.htm
 "><code>WriteConcern</code></a> is used when uploading files to GridFS, and the <a href="/mongo-csharp-driver/2.9/apidocs/html/P_MongoDB_Driver_GridFS_GridFSBucketOptions_ReadPreference.htm

--- a/2.9/reference/index.xml
+++ b/2.9/reference/index.xml
@@ -1359,9 +1359,9 @@ using (var stream = await bucket.OpenDownloadStreamByNameAsync(filename, options
 
 &lt;pre&gt;&lt;code class=&#34;language-csharp&#34;&gt;IGridFSBucket bucket;
 var filter = Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.And( 
-    Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.EQ(x =&amp;gt; x.Filename, &amp;quot;securityvideo&amp;quot;),
-    Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.GTE(x =&amp;gt; x.UploadDateTime, new DateTime(2015, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
-    Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.LT(x =&amp;gt; x.UploadDateTime, new DateTime(2015, 2, 1, 0, 0, 0, DateTimeKind.Utc)));
+    Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.Eq(x =&amp;gt; x.Filename, &amp;quot;securityvideo&amp;quot;),
+    Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.Gte(x =&amp;gt; x.UploadDateTime, new DateTime(2015, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+    Builders&amp;lt;GridFSFileInfo&amp;gt;.Filter.Lt(x =&amp;gt; x.UploadDateTime, new DateTime(2015, 2, 1, 0, 0, 0, DateTimeKind.Utc)));
 var sort = Builders&amp;lt;GridFSFileInfo&amp;gt;.Sort.Descending(x =&amp;gt; x.UploadDateTime);
 var options = new GridFSFindOptions
 {
@@ -1450,7 +1450,7 @@ var bucket = new GridFSBucket(database, new GridFSBucketOptions
 &#34;&gt;&lt;code&gt;BucketName&lt;/code&gt;&lt;/a&gt; value is the root part of the files and chunks collection names, so in this example the two collections would be named &amp;ldquo;videos.files&amp;rdquo; and &amp;ldquo;videos.chunks&amp;rdquo; instead of &amp;ldquo;fs.files&amp;rdquo; and &amp;ldquo;fs.chunks&amp;rdquo;.&lt;/p&gt;
 
 &lt;p&gt;The &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/P_MongoDB_Driver_GridFS_GridFSBucketOptions_ChunkSizeBytes.htm
-&#34;&gt;&lt;code&gt;ChunkSizeBytes&lt;/code&gt;&lt;/a&gt; value defines the size of each chunk, and in this example we are overriding the default value of 261120 (255MB).&lt;/p&gt;
+&#34;&gt;&lt;code&gt;ChunkSizeBytes&lt;/code&gt;&lt;/a&gt; value defines the size of each chunk, and in this example we are overriding the default value of 261120 (255kB).&lt;/p&gt;
 
 &lt;p&gt;The &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/P_MongoDB_Driver_GridFS_GridFSBucketOptions_WriteConcern.htm
 &#34;&gt;&lt;code&gt;WriteConcern&lt;/code&gt;&lt;/a&gt; is used when uploading files to GridFS, and the &lt;a href=&#34;/mongo-csharp-driver/2.9/mongo-csharp-driver/2.9/apidocs/html/P_MongoDB_Driver_GridFS_GridFSBucketOptions_ReadPreference.htm
@@ -1845,7 +1845,7 @@ These are heavy events to generate. Do not subscribe to these unless they provid
 &lt;h2 id=&#34;linq&#34;&gt;LINQ&lt;/h2&gt;
 
 &lt;p&gt;The driver contains an implementation of &lt;a href=&#34;https://msdn.microsoft.com/en-us/library/bb397926.aspx&#34;&gt;LINQ&lt;/a&gt; that targets the &lt;a href=&#34;http://docs.mongodb.org/manual/aggregation
-&#34;&gt;aggregation framework&lt;/a&gt;. The aggregation framework holds a rich query language that maps very easily from a LINQ expression tree making it straightforward to understand the translation from a LINQ statement into an aggregation framework pipeline. To see a more complicated uses of LINQ from the driver, see the &lt;a href=&#34;﻿https://github.com/mongodb/mongo-csharp-driver/blob/master/tests/MongoDB.Driver.Tests/Samples/AggregationSample.cs
+&#34;&gt;aggregation framework&lt;/a&gt;. The aggregation framework holds a rich query language that maps very easily from a LINQ expression tree making it straightforward to understand the translation from a LINQ statement into an aggregation framework pipeline. To see a more complicated uses of LINQ from the driver, see the &lt;a href=&#34;https://github.com/mongodb/mongo-csharp-driver/blob/master/tests/MongoDB.Driver.Tests/Samples/AggregationSample.cs
 &#34;&gt;AggregationSample&lt;/a&gt; source code.&lt;/p&gt;
 
 &lt;p&gt;For the rest of this page, we&amp;rsquo;ll use the following class:&lt;/p&gt;
@@ -2161,7 +2161,7 @@ var query = collection.AsQueryable()
 
 &lt;h3 id=&#34;supported-methods&#34;&gt;Supported Methods&lt;/h3&gt;
 
-&lt;p&gt;The method examples are shown in isolation, but they can be used and combined with all the other methods as well. You can view the tests for each of these methods in the &lt;a href=&#34;﻿https://github.com/mongodb/mongo-csharp-driver/blob/master/tests/MongoDB.Driver.Tests/Linq/MongoQueryableTests.cs
+&lt;p&gt;The method examples are shown in isolation, but they can be used and combined with all the other methods as well. You can view the tests for each of these methods in the &lt;a href=&#34;https://github.com/mongodb/mongo-csharp-driver/blob/master/tests/MongoDB.Driver.Tests/Linq/MongoQueryableTests.cs
 &#34;&gt;MongoQueryableTests&lt;/a&gt;.&lt;/p&gt;
 
 &lt;h4 id=&#34;any&#34;&gt;Any&lt;/h4&gt;

--- a/2.9/sitemap.xml
+++ b/2.9/sitemap.xml
@@ -33,11 +33,6 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.9/reference/gridfs/deletingandrenamingfiles/</loc>
-    <lastmod>2015-09-14T00:00:00+00:00</lastmod>
-  </url>
-  
-  <url>
     <loc>/mongo-csharp-driver/2.9/reference/gridfs/downloadingfiles/</loc>
     <lastmod>2015-09-14T00:00:00+00:00</lastmod>
   </url>
@@ -54,6 +49,11 @@
   
   <url>
     <loc>/mongo-csharp-driver/2.9/reference/gridfs/uploadingfiles/</loc>
+    <lastmod>2015-09-14T00:00:00+00:00</lastmod>
+  </url>
+  
+  <url>
+    <loc>/mongo-csharp-driver/2.9/reference/gridfs/deletingandrenamingfiles/</loc>
     <lastmod>2015-09-14T00:00:00+00:00</lastmod>
   </url>
   
@@ -98,7 +98,7 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.9/examples/importing_json/</loc>
+    <loc>/mongo-csharp-driver/2.9/examples/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
@@ -108,7 +108,7 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.9/getting_started/admin_quick_tour/</loc>
+    <loc>/mongo-csharp-driver/2.9/examples/importing_json/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
@@ -123,7 +123,12 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.9/examples/</loc>
+    <loc>/mongo-csharp-driver/2.9/getting_started/admin_quick_tour/</loc>
+    <lastmod>2015-03-17T15:36:56+00:00</lastmod>
+  </url>
+  
+  <url>
+    <loc>/mongo-csharp-driver/2.9/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
@@ -133,7 +138,7 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.9/</loc>
+    <loc>/mongo-csharp-driver/2.9/reference/bson/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
@@ -144,11 +149,6 @@
   
   <url>
     <loc>/mongo-csharp-driver/2.9/reference/bson/bson_document/</loc>
-    <lastmod>2015-03-17T15:36:56+00:00</lastmod>
-  </url>
-  
-  <url>
-    <loc>/mongo-csharp-driver/2.9/reference/bson/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
@@ -168,11 +168,6 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.9/reference/bson/serialization/</loc>
-    <lastmod>2015-03-17T15:36:56+00:00</lastmod>
-  </url>
-  
-  <url>
     <loc>/mongo-csharp-driver/2.9/reference/bson/mapping/schema_changes/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
@@ -188,7 +183,7 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.9/reference/driver/crud/writing/</loc>
+    <loc>/mongo-csharp-driver/2.9/reference/bson/serialization/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
@@ -198,7 +193,12 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.9/reference/driver/</loc>
+    <loc>/mongo-csharp-driver/2.9/reference/driver/crud/writing/</loc>
+    <lastmod>2015-03-17T15:36:56+00:00</lastmod>
+  </url>
+  
+  <url>
+    <loc>/mongo-csharp-driver/2.9/reference/driver/definitions/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
@@ -213,7 +213,7 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.9/reference/driver/definitions/</loc>
+    <loc>/mongo-csharp-driver/2.9/reference/driver/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   

--- a/index.html
+++ b/index.html
@@ -109,23 +109,23 @@
         <select class="driverPicker">
           
           
-          <option value="0" data-versions="2.10.0-beta1,2.9.2,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2">.NET Driver</option>
+          <option value="0" data-versions="2.10.0-beta1,2.9.3,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2">.NET Driver</option>
           
           
           
-          <option value="1" data-versions="2.10.0-beta1,2.9.2,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1">.NET GridFS</option>
+          <option value="1" data-versions="2.10.0-beta1,2.9.3,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1">.NET GridFS</option>
           
           
           
-          <option value="2" data-versions="2.10.0-beta1,2.9.2,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2">.NET Core Driver</option>
+          <option value="2" data-versions="2.10.0-beta1,2.9.3,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2">.NET Core Driver</option>
           
           
           
-          <option value="3" data-versions="2.10.0-beta1,2.9.2,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2">.NET BSON Library</option>
+          <option value="3" data-versions="2.10.0-beta1,2.9.3,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2">.NET BSON Library</option>
           
           
           
-          <option value="4" data-versions="2.10.0-beta1,2.9.2,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2,1.11">.NET Legacy Driver</option>
+          <option value="4" data-versions="2.10.0-beta1,2.9.3,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2,1.11">.NET Legacy Driver</option>
           
           
         </select>
@@ -140,7 +140,7 @@
         <option value="0"disabled="disabled">2.10.0-beta1</option>
         
         
-        <option value="1"disabled="disabled" selected="selected">2.9.2</option>
+        <option value="1"disabled="disabled" selected="selected">2.9.3</option>
         
         
         <option value="2"disabled="disabled">2.8.1</option>
@@ -181,7 +181,7 @@
     </div>
   </form>
   <div class="hidden-md hidden-sm hidden-xs col-lg-2 col-lg-pull-10 downloadLink">
-  <a id="downloadLink" href="https://www.nuget.org/api/v2/package/MongoDB.Driver/2.9.2" class="btn btn-dark btn-download" target="_blank">Download</a>
+  <a id="downloadLink" href="https://www.nuget.org/api/v2/package/MongoDB.Driver/2.9.3" class="btn btn-dark btn-download" target="_blank">Download</a>
   </div>
   </div>
 
@@ -228,16 +228,16 @@ nuget MongoDB.Driver ~> 2.10.0-beta1
           
 <div id="nuget-1-0" class="download">
 <pre><code>&lt;packages&gt;
-    &lt;package id="MongoDB.Driver" version="2.9.2" /&gt;
-    &lt;package id="MongoDB.Driver.Core" version="2.9.2" /&gt;
-    &lt;package id="MongoDB.Bson" version="2.9.2" /&gt;
+    &lt;package id="MongoDB.Driver" version="2.9.3" /&gt;
+    &lt;package id="MongoDB.Driver.Core" version="2.9.3" /&gt;
+    &lt;package id="MongoDB.Bson" version="2.9.3" /&gt;
 &lt;/packages&gt;
 </code></pre>
 </div>
 <div id="paket-1-0" class="download hidden">
 <pre><code>source https://nuget.org/api/v2
 
-nuget MongoDB.Driver ~> 2.9.2
+nuget MongoDB.Driver ~> 2.9.3
 </code></pre>
 </div>
           
@@ -500,17 +500,17 @@ nuget MongoDB.Driver.GridFS ~> 2.10.0-beta1
           
 <div id="nuget-1-1" class="download  hidden">
 <pre><code>&lt;packages&gt;
-    &lt;package id="MongoDB.Driver.GridFS" version="2.9.2" /&gt;
-    &lt;package id="MongoDB.Driver" version="2.9.2" /&gt;
-    &lt;package id="MongoDB.Driver.Core" version="2.9.2" /&gt;
-    &lt;package id="MongoDB.Bson" version="2.9.2" /&gt;
+    &lt;package id="MongoDB.Driver.GridFS" version="2.9.3" /&gt;
+    &lt;package id="MongoDB.Driver" version="2.9.3" /&gt;
+    &lt;package id="MongoDB.Driver.Core" version="2.9.3" /&gt;
+    &lt;package id="MongoDB.Bson" version="2.9.3" /&gt;
 &lt;/packages&gt;
 </code></pre>
 </div>
 <div id="paket-1-1" class="download hidden">
 <pre><code>source https://nuget.org/api/v2
 
-nuget MongoDB.Driver.GridFS ~> 2.9.2
+nuget MongoDB.Driver.GridFS ~> 2.9.3
 </code></pre>
 </div>
           
@@ -762,15 +762,15 @@ nuget MongoDB.Driver.Core ~> 2.10.0-beta1
           
 <div id="nuget-1-2" class="download  hidden">
 <pre><code>&lt;packages&gt;
-    &lt;package id="MongoDB.Driver.Core" version="2.9.2" /&gt;
-    &lt;package id="MongoDB.Bson" version="2.9.2" /&gt;
+    &lt;package id="MongoDB.Driver.Core" version="2.9.3" /&gt;
+    &lt;package id="MongoDB.Bson" version="2.9.3" /&gt;
 &lt;/packages&gt;
 </code></pre>
 </div>
 <div id="paket-1-2" class="download hidden">
 <pre><code>source https://nuget.org/api/v2
 
-nuget MongoDB.Driver.Core ~> 2.9.2
+nuget MongoDB.Driver.Core ~> 2.9.3
 </code></pre>
 </div>
           
@@ -1021,14 +1021,14 @@ nuget MongoDB.Bson ~> 2.10.0-beta1
           
 <div id="nuget-1-3" class="download  hidden">
 <pre><code>&lt;packages&gt;
-    &lt;package id="MongoDB.Bson" version="2.9.2" /&gt;
+    &lt;package id="MongoDB.Bson" version="2.9.3" /&gt;
 &lt;/packages&gt;
 </code></pre>
 </div>
 <div id="paket-1-3" class="download hidden">
 <pre><code>source https://nuget.org/api/v2
 
-nuget MongoDB.Bson ~> 2.9.2
+nuget MongoDB.Bson ~> 2.9.3
 </code></pre>
 </div>
           
@@ -1273,17 +1273,17 @@ nuget mongocsharpdriver ~> 2.10.0-beta1
           
 <div id="nuget-1-4" class="download  hidden">
 <pre><code>&lt;packages&gt;
-    &lt;package id="mongocsharpdriver" version="2.9.2" /&gt;
-    &lt;package id="MongoDB.Driver" version="2.9.2" /&gt;
-    &lt;package id="MongoDB.Driver.Core" version="2.9.2" /&gt;
-    &lt;package id="MongoDB.Bson" version="2.9.2" /&gt;
+    &lt;package id="mongocsharpdriver" version="2.9.3" /&gt;
+    &lt;package id="MongoDB.Driver" version="2.9.3" /&gt;
+    &lt;package id="MongoDB.Driver.Core" version="2.9.3" /&gt;
+    &lt;package id="MongoDB.Bson" version="2.9.3" /&gt;
 &lt;/packages&gt;
 </code></pre>
 </div>
 <div id="paket-1-4" class="download hidden">
 <pre><code>source https://nuget.org/api/v2
 
-nuget mongocsharpdriver ~> 2.9.2
+nuget mongocsharpdriver ~> 2.9.3
 </code></pre>
 </div>
           
@@ -1555,7 +1555,7 @@ nuget mongocsharpdriver ~> 1.11
       </tr>
     
       <tr>
-        <th class="current">2.9.2</th>
+        <th class="current">2.9.3</th>
         <td><a href="./2.9/" class="reference">Reference</a> &#124; <a href="./2.9/apidocs">API</a></td>
       </tr>
     


### PR DESCRIPTION
https://jira.mongodb.org/browse/CSHARP-2848
https://jira.mongodb.org/browse/CSHARP-2849

This PR, as the title indicates, contains a pair of commits and addresses a pair of tickets.
The essential thrust is the 2848 contains the changes needed to be made to the landing page (see https://github.com/vincentkam/mongo-csharp-driver/pull/75), including some hand edits to preserve the fact that we want `2.10.0-beta1` to be the listed on the page while `2.9.3` is still selected by default. The landing page was generated from master because the landing page needs to include the latest releases (in this case `2.10.0-beta1`)

2849 contains the regenerated docs for `2.9.3`, as generated from v2.9.x branch. (See also https://github.com/vincentkam/mongo-csharp-driver/pull/78)

This PR differs from https://github.com/vincentkam/mongo-csharp-driver/pull/77 in that we have not updated the 2.10 documentation, as that is outside the scope of the work needed to be done for the 2.9.3 release.

The changes have already been deployed on the gh-pages branch of my fork and should be visible here: https://vincentkam.github.io/mongo-csharp-driver/ ~once the GitHub bot has deployed it~ now.

The branch that this PR is made against (gh-pages-pr)  exists purely for review purposes.