### PR TITLE
CSHARP-2900: Update reference docs for 2.10.1

### DIFF
--- a/2.10/sitemap.xml
+++ b/2.10/sitemap.xml
@@ -83,12 +83,12 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.10/examples/tailable_cursor/</loc>
+    <loc>/mongo-csharp-driver/2.10/examples/mixing_static_and_dynamic/</loc>
     <lastmod>2015-05-26T15:36:56+00:00</lastmod>
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.10/examples/mixing_static_and_dynamic/</loc>
+    <loc>/mongo-csharp-driver/2.10/examples/tailable_cursor/</loc>
     <lastmod>2015-05-26T15:36:56+00:00</lastmod>
   </url>
   
@@ -103,12 +103,17 @@
   </url>
   
   <url>
+    <loc>/mongo-csharp-driver/2.10/examples/importing_json/</loc>
+    <lastmod>2015-03-17T15:36:56+00:00</lastmod>
+  </url>
+  
+  <url>
     <loc>/mongo-csharp-driver/2.10/examples/exporting_json/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.10/getting_started/admin_quick_tour/</loc>
+    <loc>/mongo-csharp-driver/2.10/examples/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
@@ -118,12 +123,12 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.10/getting_started/installation/</loc>
+    <loc>/mongo-csharp-driver/2.10/getting_started/admin_quick_tour/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.10/getting_started/quick_tour/</loc>
+    <loc>/mongo-csharp-driver/2.10/getting_started/installation/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
@@ -138,12 +143,12 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.10/reference/bson/bson_document/</loc>
+    <loc>/mongo-csharp-driver/2.10/getting_started/quick_tour/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.10/examples/</loc>
+    <loc>/mongo-csharp-driver/2.10/reference/bson/bson_document/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
@@ -158,11 +163,6 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.10/reference/bson/mapping/polymorphism/</loc>
-    <lastmod>2015-03-17T15:36:56+00:00</lastmod>
-  </url>
-  
-  <url>
     <loc>/mongo-csharp-driver/2.10/reference/bson/mapping/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
@@ -173,12 +173,12 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.10/reference/bson/serialization/</loc>
+    <loc>/mongo-csharp-driver/2.10/reference/bson/mapping/polymorphism/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.10/examples/importing_json/</loc>
+    <loc>/mongo-csharp-driver/2.10/reference/bson/serialization/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
@@ -198,12 +198,12 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.10/reference/driver/crud/writing/</loc>
+    <loc>/mongo-csharp-driver/2.10/reference/driver/definitions/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.10/reference/driver/definitions/</loc>
+    <loc>/mongo-csharp-driver/2.10/reference/driver/crud/writing/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
@@ -213,7 +213,7 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.10/reference/driver/expressions/</loc>
+    <loc>/mongo-csharp-driver/2.10/reference/driver/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
@@ -223,7 +223,12 @@
   </url>
   
   <url>
-    <loc>/mongo-csharp-driver/2.10/reference/driver/</loc>
+    <loc>/mongo-csharp-driver/2.10/reference/driver/expressions/</loc>
+    <lastmod>2015-03-17T15:36:56+00:00</lastmod>
+  </url>
+  
+  <url>
+    <loc>/mongo-csharp-driver/2.10/reference/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   
@@ -234,11 +239,6 @@
   
   <url>
     <loc>/mongo-csharp-driver/2.10/what_is_new/</loc>
-    <lastmod>2015-03-17T15:36:56+00:00</lastmod>
-  </url>
-  
-  <url>
-    <loc>/mongo-csharp-driver/2.10/reference/</loc>
     <lastmod>2015-03-17T15:36:56+00:00</lastmod>
   </url>
   

--- a/index.html
+++ b/index.html
@@ -109,23 +109,23 @@
         <select class="driverPicker">
           
           
-          <option value="0" data-versions="2.10.0,2.9.3,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2">.NET Driver</option>
+          <option value="0" data-versions="2.10.1,2.9.3,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2">.NET Driver</option>
           
           
           
-          <option value="1" data-versions="2.10.0,2.9.3,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1">.NET GridFS</option>
+          <option value="1" data-versions="2.10.1,2.9.3,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1">.NET GridFS</option>
           
           
           
-          <option value="2" data-versions="2.10.0,2.9.3,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2">.NET Core Driver</option>
+          <option value="2" data-versions="2.10.1,2.9.3,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2">.NET Core Driver</option>
           
           
           
-          <option value="3" data-versions="2.10.0,2.9.3,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2">.NET BSON Library</option>
+          <option value="3" data-versions="2.10.1,2.9.3,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2">.NET BSON Library</option>
           
           
           
-          <option value="4" data-versions="2.10.0,2.9.3,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2,1.11">.NET Legacy Driver</option>
+          <option value="4" data-versions="2.10.1,2.9.3,2.8.1,2.7.3,2.6.1,2.5.1,2.4.4,2.3.0,2.2.4,2.1.1,2.0.2,1.11">.NET Legacy Driver</option>
           
           
         </select>
@@ -137,7 +137,7 @@
     
       <select class="releasePicker">
         
-        <option value="0"disabled="disabled">2.10.0</option>
+        <option value="0"disabled="disabled">2.10.1</option>
         
         
         <option value="1"disabled="disabled">2.9.3</option>
@@ -181,7 +181,7 @@
     </div>
   </form>
   <div class="hidden-md hidden-sm hidden-xs col-lg-2 col-lg-pull-10 downloadLink">
-  <a id="downloadLink" href="https://www.nuget.org/api/v2/package/MongoDB.Driver/2.10.0" class="btn btn-dark btn-download" target="_blank">Download</a>
+  <a id="downloadLink" href="https://www.nuget.org/api/v2/package/MongoDB.Driver/2.10.1" class="btn btn-dark btn-download" target="_blank">Download</a>
   </div>
   </div>
 
@@ -205,16 +205,16 @@
           
 <div id="nuget-0-0" class="download ">
 <pre><code>&lt;packages&gt;
-    &lt;package id="MongoDB.Driver" version="2.10.0" /&gt;
-    &lt;package id="MongoDB.Driver.Core" version="2.10.0" /&gt;
-    &lt;package id="MongoDB.Bson" version="2.10.0" /&gt;
+    &lt;package id="MongoDB.Driver" version="2.10.1" /&gt;
+    &lt;package id="MongoDB.Driver.Core" version="2.10.1" /&gt;
+    &lt;package id="MongoDB.Bson" version="2.10.1" /&gt;
 &lt;/packages&gt;
 </code></pre>
 </div>
 <div id="paket-0-0" class="download hidden">
 <pre><code>source https://nuget.org/api/v2
 
-nuget MongoDB.Driver ~> 2.10.0
+nuget MongoDB.Driver ~> 2.10.1
 </code></pre>
 </div>
           
@@ -476,17 +476,17 @@ nuget MongoDB.Driver ~> 2.0.2
           
 <div id="nuget-0-1" class="download  hidden">
 <pre><code>&lt;packages&gt;
-    &lt;package id="MongoDB.Driver.GridFS" version="2.10.0" /&gt;
-    &lt;package id="MongoDB.Driver" version="2.10.0" /&gt;
-    &lt;package id="MongoDB.Driver.Core" version="2.10.0" /&gt;
-    &lt;package id="MongoDB.Bson" version="2.10.0" /&gt;
+    &lt;package id="MongoDB.Driver.GridFS" version="2.10.1" /&gt;
+    &lt;package id="MongoDB.Driver" version="2.10.1" /&gt;
+    &lt;package id="MongoDB.Driver.Core" version="2.10.1" /&gt;
+    &lt;package id="MongoDB.Bson" version="2.10.1" /&gt;
 &lt;/packages&gt;
 </code></pre>
 </div>
 <div id="paket-0-1" class="download hidden">
 <pre><code>source https://nuget.org/api/v2
 
-nuget MongoDB.Driver.GridFS ~> 2.10.0
+nuget MongoDB.Driver.GridFS ~> 2.10.1
 </code></pre>
 </div>
           
@@ -740,15 +740,15 @@ nuget MongoDB.Driver.GridFS ~> 2.1.1
           
 <div id="nuget-0-2" class="download  hidden">
 <pre><code>&lt;packages&gt;
-    &lt;package id="MongoDB.Driver.Core" version="2.10.0" /&gt;
-    &lt;package id="MongoDB.Bson" version="2.10.0" /&gt;
+    &lt;package id="MongoDB.Driver.Core" version="2.10.1" /&gt;
+    &lt;package id="MongoDB.Bson" version="2.10.1" /&gt;
 &lt;/packages&gt;
 </code></pre>
 </div>
 <div id="paket-0-2" class="download hidden">
 <pre><code>source https://nuget.org/api/v2
 
-nuget MongoDB.Driver.Core ~> 2.10.0
+nuget MongoDB.Driver.Core ~> 2.10.1
 </code></pre>
 </div>
           
@@ -1000,14 +1000,14 @@ nuget MongoDB.Driver.Core ~> 2.0.2
           
 <div id="nuget-0-3" class="download  hidden">
 <pre><code>&lt;packages&gt;
-    &lt;package id="MongoDB.Bson" version="2.10.0" /&gt;
+    &lt;package id="MongoDB.Bson" version="2.10.1" /&gt;
 &lt;/packages&gt;
 </code></pre>
 </div>
 <div id="paket-0-3" class="download hidden">
 <pre><code>source https://nuget.org/api/v2
 
-nuget MongoDB.Bson ~> 2.10.0
+nuget MongoDB.Bson ~> 2.10.1
 </code></pre>
 </div>
           
@@ -1249,17 +1249,17 @@ nuget MongoDB.Bson ~> 2.0.2
           
 <div id="nuget-0-4" class="download  hidden">
 <pre><code>&lt;packages&gt;
-    &lt;package id="mongocsharpdriver" version="2.10.0" /&gt;
-    &lt;package id="MongoDB.Driver" version="2.10.0" /&gt;
-    &lt;package id="MongoDB.Driver.Core" version="2.10.0" /&gt;
-    &lt;package id="MongoDB.Bson" version="2.10.0" /&gt;
+    &lt;package id="mongocsharpdriver" version="2.10.1" /&gt;
+    &lt;package id="MongoDB.Driver" version="2.10.1" /&gt;
+    &lt;package id="MongoDB.Driver.Core" version="2.10.1" /&gt;
+    &lt;package id="MongoDB.Bson" version="2.10.1" /&gt;
 &lt;/packages&gt;
 </code></pre>
 </div>
 <div id="paket-0-4" class="download hidden">
 <pre><code>source https://nuget.org/api/v2
 
-nuget mongocsharpdriver ~> 2.10.0
+nuget mongocsharpdriver ~> 2.10.1
 </code></pre>
 </div>
           
@@ -1550,7 +1550,7 @@ nuget mongocsharpdriver ~> 1.11
     <tbody>
     
       <tr>
-        <th class="">2.10.0</th>
+        <th class="">2.10.1</th>
         <td><a href="./2.10/" class="reference">Reference</a> &#124; <a href="./2.10/apidocs">API</a></td>
       </tr>
     


### PR DESCRIPTION
Changes live at https://vincentkam.github.io/mongo-csharp-driver/

There is a known issue with the NuGet/Paket toggle: https://jira.mongodb.org/browse/CSHARP-2901. This issue is present on the main page as well. https://mongodb.github.io/mongo-csharp-driver/